### PR TITLE
scipy.misc.imread is deprecated

### DIFF
--- a/fid.py
+++ b/fid.py
@@ -44,7 +44,8 @@ from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
 import numpy as np
 import torch
 from scipy import linalg
-from scipy.misc import imread
+# from scipy.misc import imread
+from imageio import imread
 from torch.nn.functional import adaptive_avg_pool2d
 
 try:


### PR DESCRIPTION
The script works as long as the image size of both dataset are the same
![image](https://user-images.githubusercontent.com/44915027/70839682-d5c93c80-1ddb-11ea-8099-c0265d07577f.png)
